### PR TITLE
feat: add Route53 records edit/delete modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ hibiscus --profile prod # with AWS CLI profile
 - `Enter` – drill down one level (repo → images, zone → records, load balancer → listeners → rules)
 - `Esc` – back out of the current level or exit filter mode
 - `R` – refresh the active view
+- `e` / `Ctrl+D` (Route53 records) – edit the selected record's type/value/TTL or confirm deletion before removing it
 - `Ctrl+C` – quit the application
 
 ### Route53 tview proof of concept
@@ -92,7 +93,7 @@ Note that AWS profile settings are NOT persisted and must be provided with the `
 | :---------------------: | :--: | :--: | :-----------------------------------------------------------------------------------: |
 |       Amazon ECR        |  ✓   |  ✕   |           Easily store, share, and deploy your container software anywhere            |
 |     AWS ECR Public      |  ✕   |  ✕   |      Easily store, share, and deploy your container software anywhere in public       |
-|     Amazon Route53      |  ✓   |  ✕   |     A reliable and cost-effective way to route end users to Internet applications     |
+|     Amazon Route53      |  ✓   |  ✓   |     Browse hosted zones and edit record type/value/TTL directly from the TUI         |
 |       Amazon ELB        |  ✓   |  ✕   |             Distribute network traffic to improve application scalability             |
 | AWS SSM Parameter Store |  ✕   |  ✕   | Secure, hierarchical storage for configuration data management and secrets management |
 

--- a/internal/aws/route53/route53.go
+++ b/internal/aws/route53/route53.go
@@ -182,6 +182,26 @@ func UpsertRecord(hostedZoneID *string, record types.ResourceRecordSet) error {
 	return err
 }
 
+func DeleteRecord(hostedZoneID *string, record types.ResourceRecordSet) error {
+	if err := setupClient(); err != nil {
+		return err
+	}
+
+	_, err := client.ChangeResourceRecordSets(context.TODO(), &route53.ChangeResourceRecordSetsInput{
+		HostedZoneId: hostedZoneID,
+		ChangeBatch: &types.ChangeBatch{
+			Changes: []types.Change{
+				{
+					Action:            types.ChangeActionDelete,
+					ResourceRecordSet: &record,
+				},
+			},
+		},
+	})
+
+	return err
+}
+
 func setupClient() error {
 	if client != nil {
 		return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to edit Route53 record type, value, and TTL directly from the TUI.
  * Added record deletion functionality with confirmation dialog.
  * Added keyboard shortcuts: E to edit and Ctrl+D to delete selected records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->